### PR TITLE
Provide initial MVP

### DIFF
--- a/@/components/about-event/index.tsx
+++ b/@/components/about-event/index.tsx
@@ -52,11 +52,15 @@ export default function AboutEvent() {
 
       </div>
 
+
+
+
+
       <div className="mx-auto mb-10 mt-20 grid max-w-5xl items-start gap-3 lg:grid-cols-3">
         {eventThings.map((thing, index) => (
           <button
             key={index}
-            className="rounded-lg  border-2  p-4 transition duration-200 hover:bg-emerald-200 border-emerald-300"
+            className="flex flex-col justify-start h-full rounded-lg border-2 p-4 transition duration-200 hover:bg-emerald-200 border-emerald-300"
             onClick={() => setCurrentThing(index)}
             onMouseEnter={() => setCurrentThing(index)}
           >

--- a/@/components/about-event/index.tsx
+++ b/@/components/about-event/index.tsx
@@ -61,7 +61,6 @@ export default function AboutEvent() {
           <button
             key={index}
             className="flex flex-col justify-start h-full rounded-lg border-2 p-4 transition duration-200 hover:bg-emerald-200 border-emerald-300"
-            onClick={() => setCurrentThing(index)}
             onMouseEnter={() => setCurrentThing(index)}
           >
             <h3 className="mb-4 text-left text-xl font-semibold tracking-wide text-emerald-600 lg:text-2xl">

--- a/@/components/about-event/index.tsx
+++ b/@/components/about-event/index.tsx
@@ -3,21 +3,21 @@ import { useState } from "react";
 export default function AboutEvent() {
   const eventThings = [
     {
-      title: "Marató de PRs",
-      description:
-        "Tindrem un espai on podrem fer PRs a diferents projectes open source per si vols portar-te el portatil!",
-      image: "/images/event_10.jpg",
-    },
-    {
       title: "Xerrades i tallers",
       description:
-        "Tindrem xerrades i tallers sobre diferents temes relacionats amb l'Open Source.",
+        "Aprendràs de la mà d'experts del món de l'Open Source. Decubriràs noves eines per implementar a la teva empresa o activitat",
       image: "/images/event_8.jpg",
+    },
+    {
+      title: "Marató de PRs",
+      description:
+        "Col·labora amb l'Open Source sigui quin sigui el teu nivell. Pensa en dur el teu portàtil!",
+      image: "/images/event_10.jpg",
     },
     {
       title: "Lightning talks",
       description:
-        "Durant la jornada si vols compartir alguna cosa amb la resta podras fer-ho en una lightning talk.",
+        "Si vols compartir alguna cosa amb la resta podras fer-ho en una lightning talk.",
       image: "/images/event_9.jpg",
     },
   ];
@@ -33,12 +33,16 @@ export default function AboutEvent() {
           </h2>
 
           <p className="mt-6 space-y-6 font-display text-2xl tracking-tight text-blue-900">
-            Serà una trobada presencial a Girona el dissabte 21/10/2023 a
-            l'espai de la Fundació ”la Caixa” de Girona.
+            Ens reunirem en una trobada presencial a Girona el dissabte 19/10/2024 a Girona.
           </p>
+
           <p className="mt-6 space-y-6 font-display text-2xl tracking-tight text-blue-900">
-            Començarem a les 9:30h i finalitzarem a les 19h, amb una pausa per
-            dinar.
+            Començarem a les 9:30h i finalitzarem a les 19h, amb una pausa per dinar. 
+          </p>
+
+          <p className="mt-6 space-y-6 font-display text-2xl tracking-tight text-blue-900">
+            Gaudirem junts d'una jornada amb moltes activitats: xerrades, tallers per a tots els nivells i perfils, 
+            lighting talks, marató de PRS i molt més!
           </p>
         </div>
 

--- a/@/components/about-event/index.tsx
+++ b/@/components/about-event/index.tsx
@@ -58,6 +58,7 @@ export default function AboutEvent() {
             key={index}
             className="rounded-lg  border-2  p-4 transition duration-200 hover:bg-emerald-200 border-emerald-300"
             onClick={() => setCurrentThing(index)}
+            onMouseEnter={() => setCurrentThing(index)}
           >
             <h3 className="mb-4 text-left text-xl font-semibold tracking-wide text-emerald-600 lg:text-2xl">
               {thing.title}

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -90,11 +90,11 @@ export default function Index() {
                   Sobre Nosaltres
                 </h2>
                 <p className="mt-6 space-y-6 font-display text-2xl tracking-tight text-blue-900">
-                  Som un grup de persones interessades en el món de l'Open
-                  Source de l'associació{" "}
-                  <span className="year font-bold">GeeksCAT</span> que
-                  organitzem esdeveniments per promoure la cultura de l'Open
-                  Source a Girona.
+                  L'associació{" "}<span className="year font-bold">Geeks.CAT</span> és un grup de professionals, 
+                  empreses i estudiants interessats en el món de l'Open Source.
+                </p>
+                <p>
+                  Organitzem esdeveniments per promoure l'Open Source a Girona
                 </p>
               </div>
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -93,7 +93,7 @@ export default function Index() {
                   L'associació{" "}<span className="year font-bold">Geeks.CAT</span> és un grup de professionals, 
                   empreses i estudiants interessats en el món de l'Open Source.
                 </p>
-                <p>
+                <p className="mt-6 space-y-6 font-display text-2xl tracking-tight text-blue-900">
                   Organitzem esdeveniments per promoure l'Open Source a Girona
                 </p>
               </div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -103,25 +103,6 @@ export default function Index() {
               </div>
             </div>
 
-            <h2 className="text-emerald-600 font-semibold text-2xl md:text-4xl md:leading-tight">
-              Descobreix i comparteix
-            </h2>
-
-            <p className="mt-1 text-emerald-800">
-              Vols fer visible alguna eina/app/blibioteca open source per
-              compartir-la amb la comunitat?
-            </p>
-            <div className="mt-4 mb-4">
-              <Link
-                to="/add"
-                replace={true}
-                className="bg-neutral-900 relative z-10 w-fit hover:bg-neutral-700 border border-transparent text-white text-sm md:text-sm transition font-medium duration-200 rounded-full px-4 py-2 flex items-center justify-center shadow-[0px_-1px_0px_0px_#FFFFFF40_inset,_0px_1px_0px_0px_#FFFFFF40_inset]"
-              >
-                Afegeix-la aquí
-              </Link>
-              <HoverEffect items={openSourceProjects}></HoverEffect>
-            </div>
-
             <div className="mb-10 flex flex-col items-center justify-center">
               <h2 className="font-display text-5xl font-bold tracking-tighter text-emerald-500 sm:text-5xl">
                 Vols col·laborar fent una xerrada o taller?
@@ -152,6 +133,26 @@ export default function Index() {
             </div>
 
             <AboutEvent />
+
+            <h2 className="text-emerald-600 font-semibold text-2xl md:text-4xl md:leading-tight">
+              Descobreix i comparteix
+            </h2>
+
+            <p className="mt-1 text-emerald-800">
+              Vols fer visible alguna eina/app/blibioteca OpenSource per
+              compartir-la amb la comunitat?
+            </p>
+            <div className="mt-4 mb-4">
+              <Link
+                to="/add"
+                replace={true}
+                className="bg-neutral-900 relative z-10 w-fit hover:bg-neutral-700 border border-transparent text-white text-sm md:text-sm transition font-medium duration-200 rounded-full px-4 py-2 flex items-center justify-center shadow-[0px_-1px_0px_0px_#FFFFFF40_inset,_0px_1px_0px_0px_#FFFFFF40_inset]"
+              >
+                Afegeix-la aquí
+              </Link>
+              <HoverEffect items={openSourceProjects}></HoverEffect>
+            </div>
+
           </div>
         </div>
       </TracingBeam>


### PR DESCRIPTION
Updates landing page copies with [latest texts](https://docs.google.com/spreadsheets/d/1s0M4lxxl5p4k2xBqkfsRz5Sux-BZa6-Oigmo4p7VLos/edit?gid=361487766#gid=361487766) for sections
- `sobre nosaltres`
- `què farem`

[WIP] Also provides new `/patrocina` page

It also
- `què farem`
  - populates selected thing while hovering an option (instead of click)
  - all `things` have now the same height
- moves `Descobreix i comparteix` section to the bottom to prioritize MVP content (can/will be moved to top when we get closer to the event date) 